### PR TITLE
Setup publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ allprojects {
     repositories {
         google()
         jcenter()
+        // See https://bintray.com/mercari-inc/maven
+        maven { url 'https://dl.bintray.com/mercari-inc/maven' }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,3 +17,19 @@ allprojects {
         jcenter()
     }
 }
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}
+
+// Publishing cross project setup
+
+ext.version = System.getenv("BITRISE_GIT_TAG")?.replaceAll("v", "") ?:
+        System.getenv("BITRISE_GIT_BRANCH")?.replace("/", "-") ?:
+                "WIP"
+println("Version: $ext.version")
+
+allprojects {
+    group = 'com.mercari.puree'
+    version = rootProject.ext.version
+}

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.2'
+        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }
 }
 

--- a/buildSrc/src/main/java/BuildSettings.kt
+++ b/buildSrc/src/main/java/BuildSettings.kt
@@ -4,3 +4,10 @@ object BuildSettings {
     const val targetSdkVersion = 28
     const val compileSdkVersion = 28
 }
+
+object Publishing {
+    const val description = "Puree is a data collector and unified logging layer for Android."
+    const val url = "https://github.com/mercari/puree-android"
+    const val issueUrl = "$url/issues"
+    const val licenseUrl = "https://raw.githubusercontent.com/mercari/puree-android/master/LICENSE.txt"
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/puree/build.gradle
+++ b/puree/build.gradle
@@ -104,12 +104,7 @@ project.afterEvaluate {
                     dependencyNode.appendNode('version', dep.version)
                     dependencyNode.appendNode('scope', scope)
 
-                    if (!dep.transitive) {
-                        // If this dependency is transitive, we should force exclude all its dependencies them from the POM
-                        final exclusionNode = dependencyNode.appendNode('exclusions').appendNode('exclusion')
-                        exclusionNode.appendNode('groupId', '*')
-                        exclusionNode.appendNode('artifactId', '*')
-                    } else if (!dep.properties.excludeRules.empty) {
+                    if (!dep.properties.excludeRules.empty) {
                         // Otherwise add specified exclude rules
                         final exclusionNode = dependencyNode.appendNode('exclusions').appendNode('exclusion')
                         dep.properties.excludeRules.each { ExcludeRule rule ->

--- a/puree/build.gradle
+++ b/puree/build.gradle
@@ -1,16 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'maven'
-apply plugin: 'maven-publish'
-apply plugin: 'com.jfrog.bintray'
-
-group = 'com.github.mercari'
-
-def GROUP_ID = 'com.mercari.puree'
-def ARTIFACT_ID = 'puree'
-def VERSION = "5.0.0"
-
-project.version = VERSION
-println "building ${GROUP_ID}:${ARTIFACT_ID}:${VERSION}"
 
 android {
     compileSdkVersion BuildSettings.compileSdkVersion
@@ -18,8 +6,6 @@ android {
     defaultConfig {
         minSdkVersion BuildSettings.minSdkVersion
         targetSdkVersion BuildSettings.targetSdkVersion
-        versionCode 1
-        versionName VERSION
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -47,32 +33,6 @@ android {
     }
 }
 
-android.libraryVariants.all { variant ->
-    if (variant.buildType.isDebuggable()) {
-        return; // Skip debug builds.
-    }
-    task("javadoc${variant.name.capitalize()}", type: Javadoc) {
-        description "Generates Javadoc for $variant.name."
-        source = variant.javaCompile.source
-
-        // Add all of your dependencies and android jars to the classpath
-        classpath += files(variant.javaCompile.classpath.files)
-        classpath += files(android.getBootClasspath())
-        exclude '**/BuildConfig.java'
-        exclude '**/R.java'
-
-        options.links("http://docs.oracle.com/javase/7/docs/api/")
-        options.linksOffline("http://d.android.com/reference", "${android.sdkDirectory}/docs/reference")
-        options.charSet("utf-8")
-    }
-
-    task("bundleJavadoc${variant.name.capitalize()}", type: Jar) {
-        description "Bundles Javadoc into zip for $variant.name."
-        classifier = "javadoc"
-        from tasks["javadoc${variant.name.capitalize()}"]
-    }
-}
-
 dependencies {
     api Libs.gson
     api Libs.protobuf_lite
@@ -90,48 +50,36 @@ dependencies {
     androidTestImplementation TestLibs.androidXTestJUnit
 }
 
-task androidJar(type: Jar) {
-    from 'build/intermediates/javac/release/compileReleaseJavaWithJavac/classes'
-    exclude '**/BuildConfig.class'
-    exclude '**/R.class'
-    includeEmptyDirs false
-}
+// Publishing
+
+apply plugin: 'maven-publish'
 
 task androidSourcesJar(type: Jar) {
     classifier = 'sources'
     from android.sourceSets.main.java.srcDirs
 }
 
-task androidJavadocJar(type: Jar) {
-    classifier = 'javadoc'
-    from 'build/docs/javadoc'
-}
+// Required in order to use bundleReleaseAar task
+// See https://stackoverflow.com/a/42160584
+project.afterEvaluate {
+    publishing.publications {
+        "maven"(MavenPublication) {
+            groupId project.group
+            artifactId project.name
+            version project.version
 
-artifacts {
-    archives androidJar
-    archives androidSourcesJar
-    archives androidJavadocJar
-}
-
-publishing {
-    publications {
-        mavenAndroid(MavenPublication) {
-            groupId GROUP_ID
-            artifactId ARTIFACT_ID
-            version VERSION
-            artifact androidJar
             artifact androidSourcesJar
-            artifact androidJavadocJar
+            artifact bundleReleaseAar
+
             pom.withXml {
                 Node root = asNode()
                 root.appendNode('name', 'puree')
-                root.appendNode('description',
-                        'Puree is a data collector and unified logging layer for Android.')
-                root.appendNode('url', 'https://github.com/mercari/puree-android')
+                root.appendNode('description', Publishing.description)
+                root.appendNode('url', Publishing.url)
 
                 def issues = root.appendNode('issueManagement')
                 issues.appendNode('system', 'github')
-                issues.appendNode('url', 'https://github.com/mercari/puree-android/issues')
+                issues.appendNode('url', Publishing.issueUrl)
 
                 def scm = root.appendNode('scm')
                 scm.appendNode('url', 'scm:https://github.com/mercari/puree-android')
@@ -140,46 +88,66 @@ publishing {
 
                 def license = root.appendNode('licenses').appendNode('license')
                 license.appendNode('name', 'MIT')
-                license.appendNode('url',
-                        'https://raw.githubusercontent.com/mercari/puree-android/master/LICENSE.txt')
+                license.appendNode('url', Publishing.licenseUrl)
                 license.appendNode('distribution', 'repo')
+
+                // Add all dependencies in pom metadata
+                final dependenciesNode = root.appendNode('dependencies')
+
+                ext.addDependency = { Dependency dep, String scope ->
+                    if (dep.group == null || dep.version == null || dep.name == null || dep.name == "unspecified")
+                        return // ignore invalid dependencies
+
+                    final dependencyNode = dependenciesNode.appendNode('dependency')
+                    dependencyNode.appendNode('groupId', dep.group)
+                    dependencyNode.appendNode('artifactId', dep.name)
+                    dependencyNode.appendNode('version', dep.version)
+                    dependencyNode.appendNode('scope', scope)
+
+                    if (!dep.transitive) {
+                        // If this dependency is transitive, we should force exclude all its dependencies them from the POM
+                        final exclusionNode = dependencyNode.appendNode('exclusions').appendNode('exclusion')
+                        exclusionNode.appendNode('groupId', '*')
+                        exclusionNode.appendNode('artifactId', '*')
+                    } else if (!dep.properties.excludeRules.empty) {
+                        // Otherwise add specified exclude rules
+                        final exclusionNode = dependencyNode.appendNode('exclusions').appendNode('exclusion')
+                        dep.properties.excludeRules.each { ExcludeRule rule ->
+                            exclusionNode.appendNode('groupId', rule.group ?: '*')
+                            exclusionNode.appendNode('artifactId', rule.module ?: '*')
+                        }
+                    }
+                }
+
+                // List all "compile" dependencies (for old Gradle)
+                configurations.compile.getDependencies().each { dep -> addDependency(dep, "compile") }
+                // List all "api" dependencies (for new Gradle) as "compile" dependencies
+                configurations.api.getDependencies().each { dep -> addDependency(dep, "compile") }
+                // List all "implementation" dependencies (for new Gradle) as "runtime" dependencies
+                configurations.implementation.getDependencies().each { dep -> addDependency(dep, "runtime") }
             }
         }
     }
 }
 
-def getBintrayUserProperty() {
-    return hasProperty('bintrayUser') ? bintrayUser : ""
-}
-
-def getBintrayKeyProperty() {
-    return hasProperty('bintrayKey') ? bintrayKey : ""
-}
-
-def getBintrayDryRunProperty() {
-    return hasProperty('dryRun') ? Boolean.parseBoolean(dryRun) : false
-}
+apply plugin: 'com.jfrog.bintray'
 
 bintray {
-    user = bintrayUserProperty
-    key = bintrayKeyProperty
-    dryRun = bintrayDryRunProperty
-    publications = ['mavenAndroid']
+    user = System.getenv("BINTRAY_USER")
+    key = System.getenv("BINTRAY_API_KEY")
+
+    setPublications("maven")
+    setConfigurations("archives")
+
     publish = true
+
     pkg {
         repo = 'maven'
         name = 'puree'
-        licenses = ['MIT']
+        desc = Publishing.description
+        websiteUrl = Publishing.url
+        issueTrackerUrl = Publishing.issueUrl
         vcsUrl = 'https://github.com/mercari/puree-android.git'
+        licenses = ['MIT']
     }
 }
-
-// execute shell which publishes javadoc with version info
-task deployJavadoc(type: Exec) {
-    workingDir '../'
-    executable "./deploy_javadoc.sh"
-    args VERSION
-}
-
-// call deployJavadoc after bintrayUpload task
-bintrayUpload.finalizedBy(deployJavadoc)

--- a/puree/build.gradle
+++ b/puree/build.gradle
@@ -105,7 +105,7 @@ project.afterEvaluate {
                     dependencyNode.appendNode('scope', scope)
 
                     if (!dep.properties.excludeRules.empty) {
-                        // Otherwise add specified exclude rules
+                        // Add specified exclude rules
                         final exclusionNode = dependencyNode.appendNode('exclusions').appendNode('exclusion')
                         dep.properties.excludeRules.each { ExcludeRule rule ->
                             exclusionNode.appendNode('groupId', rule.group ?: '*')


### PR DESCRIPTION
This PR is:

- updating Gradle wrapper version
- gradle plugins (Android, Bintray)
- clean publishing to push to Jcenter
- temporarily disable javadoc generation, need to be clean as well

Tests:

1. test that maven artifacts are correctly generated can be tested manually with `./gradlew puree:publishToMavenLocal` , output will be in `~/.m2/repository/com/mercari/puree`
2. a. to test publishing on your own Jcenter repo, run `BITRISE_GIT_TAG=v0.1 BINTRAY_USER=$user BINTRAY_API_KEY=$key ./gradlew puree:artifactoryPublish`
2. b. to test publishing with CI integration, create a [new release](https://github.com/mercari/puree-android/releases) and see output in [Mercari Bintray](https://bintray.com/mercari-inc/maven/puree)