### PR TITLE
Replace the latest version badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Puree [![Build Status](https://travis-ci.org/cookpad/puree-android.svg?branch=master)](https://travis-ci.org/cookpad/puree-android)  [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Puree-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1170) [ ![Download](https://api.bintray.com/packages/cookpad/maven/puree/images/download.svg) ](https://bintray.com/cookpad/maven/puree/_latestVersion)
+Puree [![Build Status](https://travis-ci.org/cookpad/puree-android.svg?branch=master)](https://travis-ci.org/cookpad/puree-android)  [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Puree-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1170) [ ![Download](https://api.bintray.com/packages/mercari-inc/maven/puree/images/download.svg) ](https://bintray.com/mercari-inc/maven/puree/_latestVersion)
 ====
 
 # Description


### PR DESCRIPTION
This is just for changing the badge of JFrog.

https://bintray.com/mercari-inc/maven/puree

![Screen Shot 2019-06-18 at 19 26 20](https://user-images.githubusercontent.com/8059722/59674801-fa62a400-91fe-11e9-97af-3d6ca5f14b0c.png)
