### PR TITLE
Added tagpattern feature similar to puree-ios | Step 1/3

### DIFF
--- a/puree/src/androidTest/java/com/mercari/puree/TagPatternTest.java
+++ b/puree/src/androidTest/java/com/mercari/puree/TagPatternTest.java
@@ -46,8 +46,11 @@ public class TagPatternTest {
 
     @Test
     public void testInvalidPatterns() {
+        assertNull(TagPattern.fromString(". . "));
         assertNull(TagPattern.fromString("a..b.c"));
         assertNull(TagPattern.fromString(""));
+        assertNull(TagPattern.fromString("."));
+        assertNull(TagPattern.fromString(".."));
         assertNull(TagPattern.fromString("a. .c"));
         assertNull(TagPattern.fromString("a.\n.c"));
         assertNull(TagPattern.fromString("a.b.c\n"));

--- a/puree/src/androidTest/java/com/mercari/puree/TagPatternTest.java
+++ b/puree/src/androidTest/java/com/mercari/puree/TagPatternTest.java
@@ -1,0 +1,55 @@
+package com.mercari.puree;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class TagPatternTest {
+
+    @Test
+    public void testMatchesSuccess() {
+        assertTrue(TagPattern.fromString("aaa").match("aaa"));
+        assertTrue(TagPattern.fromString("aaa.bbb").match("aaa.bbb"));
+        assertTrue(TagPattern.fromString("aaa.*").match("aaa.bbb"));
+        assertTrue(TagPattern.fromString("aaa.*").match("aaa.ccc"));
+        assertTrue(TagPattern.fromString("aaa.*.ccc").match("aaa.bbb.ccc"));
+        assertTrue(TagPattern.fromString("*").match("aaa"));
+        assertTrue(TagPattern.fromString("*").match("bbb"));
+        assertTrue(TagPattern.fromString("*").match(""));
+        assertTrue(TagPattern.fromString("a.**").match("a"));
+        assertTrue(TagPattern.fromString("a.**").match("a.b"));
+        assertTrue(TagPattern.fromString("a.**").match("a.b.c"));
+        assertTrue(TagPattern.fromString("a.*.*.c").match("a.b.d.c"));
+        assertTrue(TagPattern.fromString("a.**.g").match("a.b.c.d.e.f.g"));
+        assertTrue(TagPattern.fromString("**").match(""));
+        assertTrue(TagPattern.fromString("**").match("``!!``"));
+    }
+
+    @Test
+    public void testMatchesFailure() {
+        assertFalse(TagPattern.fromString("bbb").match("aaa"));
+        assertFalse(TagPattern.fromString("*").match("aaa.bbb"));
+        assertFalse(TagPattern.fromString("aaa.*").match("aaa.bbb.ccc"));
+        assertFalse(TagPattern.fromString("aaa.*.ccc").match("aaa.bbb.ddd"));
+        assertFalse(TagPattern.fromString("a.**").match("b.c"));
+        assertFalse(TagPattern.fromString("a.**.e").match("a.b.c.d"));
+        assertFalse(TagPattern.fromString("a.*.*.c").match("a.b.c"));
+        assertFalse(TagPattern.fromString("a").match(""));
+        assertFalse(TagPattern.fromString("a").match("``!!"));
+    }
+
+    @Test
+    public void testInvalidPatterns() {
+        assertNull(TagPattern.fromString("a..b.c"));
+        assertNull(TagPattern.fromString(""));
+        assertNull(TagPattern.fromString("a. .c"));
+        assertNull(TagPattern.fromString("a.\n.c"));
+        assertNull(TagPattern.fromString("a.b.c\n"));
+    }
+}

--- a/puree/src/main/java/com/mercari/puree/TagPattern.java
+++ b/puree/src/main/java/com/mercari/puree/TagPattern.java
@@ -26,6 +26,9 @@ public final class TagPattern {
      * @return whether pattern is valid
      */
     private static boolean isValidPattern(String pattern) {
+        if (pattern == null) {
+            return false;
+        }
         String[] patternElements = pattern.split(SEPARATOR);
         if (patternElements.length == 0) {
             return false;

--- a/puree/src/main/java/com/mercari/puree/TagPattern.java
+++ b/puree/src/main/java/com/mercari/puree/TagPattern.java
@@ -1,0 +1,96 @@
+package com.mercari.puree;
+
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+
+public class TagPattern {
+
+    private static final String SEPARATOR = "\\.";
+    private static final String ALL_WILD_CARD = "**";
+    private static final String WILD_CARD = "*";
+    private static final Pattern VALID_PATTERN_ALPHANUMERIC = Pattern.compile("^[A-Za-z0-9]+");
+
+    private String pattern;
+
+    public TagPattern() {
+        this.pattern = ALL_WILD_CARD;
+    }
+
+    private TagPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    /**
+     * Patterns should follow the following pattern:
+     * • No consecutive periods
+     * • Accepts only alphanumeric, '*', '**', and '.'
+     * @param pattern to be matched
+     * @return whether pattern is valid
+     */
+    private static boolean isValidPattern(String pattern) {
+        String[] patternElements = pattern.split(SEPARATOR);
+        for (String patternPath : patternElements) {
+            if (!VALID_PATTERN_ALPHANUMERIC.matcher(patternPath).matches() &&
+                    !patternPath.equals(ALL_WILD_CARD) &&
+                    !patternPath.equals(WILD_CARD)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Matches tag based on the pattern specified in TagPattern
+     *
+     * @param tag
+     * @return whether tag matches pattern scheme
+     */
+    boolean match(String tag) {
+        if (tag.equals(pattern)) {
+            return true;
+        }
+        String[] patternElements = pattern.split(SEPARATOR);
+        String[] tagElements = tag.split(SEPARATOR);
+        int patternIndex = 0;
+        int tagIndex = 0;
+        boolean isAllWildCard = false;
+        while (tagIndex < tagElements.length && patternIndex < patternElements.length) {
+            if (patternElements[patternIndex].equals(ALL_WILD_CARD)) {
+                isAllWildCard = true;
+            } else if (!patternElements[patternIndex].equals(WILD_CARD)) {
+                if (!patternElements[patternIndex].equals(tagElements[tagIndex])) {
+                    if (isAllWildCard) {
+                        tagIndex++;
+                        continue;
+                    }
+                    return false;
+                } else {
+                    isAllWildCard = false;
+                }
+            }
+            tagIndex++;
+            patternIndex++;
+        }
+        // AllWildCard at the end
+        if (isAllWildCard && patternIndex == patternElements.length) {
+            return true;
+        }
+        if (tagIndex == tagElements.length) {
+            return patternIndex == patternElements.length ||
+                    patternElements[patternElements.length - 1].equals(ALL_WILD_CARD);
+        }
+        return false;
+    }
+
+    /**
+     * @return A TagPattern that fits the expected structure, null otherwise
+     */
+    @Nullable
+    static TagPattern fromString(String pattern) {
+        if (!isValidPattern(pattern)) {
+            return null;
+        }
+        return new TagPattern(pattern);
+    }
+}

--- a/puree/src/main/java/com/mercari/puree/TagPattern.java
+++ b/puree/src/main/java/com/mercari/puree/TagPattern.java
@@ -2,20 +2,17 @@ package com.mercari.puree;
 
 import java.util.regex.Pattern;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-public class TagPattern {
+public final class TagPattern {
 
     private static final String SEPARATOR = "\\.";
     private static final String ALL_WILD_CARD = "**";
     private static final String WILD_CARD = "*";
     private static final Pattern VALID_PATTERN_ALPHANUMERIC = Pattern.compile("^[A-Za-z0-9]+");
 
-    private String pattern;
-
-    public TagPattern() {
-        this.pattern = ALL_WILD_CARD;
-    }
+    private final String pattern;
 
     private TagPattern(String pattern) {
         this.pattern = pattern;
@@ -30,6 +27,9 @@ public class TagPattern {
      */
     private static boolean isValidPattern(String pattern) {
         String[] patternElements = pattern.split(SEPARATOR);
+        if (patternElements.length == 0) {
+            return false;
+        }
         for (String patternPath : patternElements) {
             if (!VALID_PATTERN_ALPHANUMERIC.matcher(patternPath).matches() &&
                     !patternPath.equals(ALL_WILD_CARD) &&
@@ -46,7 +46,7 @@ public class TagPattern {
      * @param tag
      * @return whether tag matches pattern scheme
      */
-    boolean match(String tag) {
+    public boolean match(String tag) {
         if (tag.equals(pattern)) {
             return true;
         }
@@ -87,10 +87,37 @@ public class TagPattern {
      * @return A TagPattern that fits the expected structure, null otherwise
      */
     @Nullable
-    static TagPattern fromString(String pattern) {
-        if (!isValidPattern(pattern)) {
+    public static TagPattern fromString(String pattern) {
+        if (pattern == null || !isValidPattern(pattern)) {
             return null;
         }
         return new TagPattern(pattern);
+    }
+
+    @Nonnull
+    public static TagPattern getDefaultInstance() {
+        return new TagPattern(ALL_WILD_CARD);
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    @Override
+    public int hashCode() {
+        return pattern.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof TagPattern)) return false;
+        final TagPattern tagPattern = (TagPattern) obj;
+        return this.pattern.equals(tagPattern.pattern);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("TagPattern(%s)", pattern);
     }
 }


### PR DESCRIPTION
**Summary**
In order to filter PureeOutputs that share the same logClass, we decided to add TagPattern logic similar to what [puree-swift](https://github.com/cookpad/Puree-Swift/blob/master/Sources/Puree/TagPattern.swift) has. This will be done in 3 steps:
- Add TagPattern with tests
- Apply TagPattern logic to puree with tests
- Update Demo app/Readme with tagpattern

[Design Doc](https://docs.google.com/document/d/19sl4ShBw9odeOQA5fpLOmGFvQeN0jzXqMFrosx7q3TM/edit#)

