### PR TITLE
Added tagpattern feature similar to puree-ios | Step 2/3

### DIFF
--- a/puree/src/androidTest/java/com/mercari/puree/TagPatternTest.java
+++ b/puree/src/androidTest/java/com/mercari/puree/TagPatternTest.java
@@ -27,8 +27,10 @@ public class TagPatternTest {
         assertTrue(TagPattern.fromString("a.**").match("a.b.c"));
         assertTrue(TagPattern.fromString("a.*.*.c").match("a.b.d.c"));
         assertTrue(TagPattern.fromString("a.**.g").match("a.b.c.d.e.f.g"));
+        assertTrue(TagPattern.fromString("a.").match("a"));
         assertTrue(TagPattern.fromString("**").match(""));
         assertTrue(TagPattern.fromString("**").match("``!!``"));
+        assertTrue(TagPattern.fromString("tag.**").match("tag"));
     }
 
     @Test
@@ -37,6 +39,8 @@ public class TagPatternTest {
         assertFalse(TagPattern.fromString("*").match("aaa.bbb"));
         assertFalse(TagPattern.fromString("aaa.*").match("aaa.bbb.ccc"));
         assertFalse(TagPattern.fromString("aaa.*.ccc").match("aaa.bbb.ddd"));
+        assertFalse(TagPattern.fromString("aaa.ccc").match("aaa"));
+        assertFalse(TagPattern.fromString("aaa").match("aaa.ccc"));
         assertFalse(TagPattern.fromString("a.**").match("b.c"));
         assertFalse(TagPattern.fromString("a.**.e").match("a.b.c.d"));
         assertFalse(TagPattern.fromString("a.*.*.c").match("a.b.c"));

--- a/puree/src/androidTest/java/com/mercari/puree/TagPatternTest.java
+++ b/puree/src/androidTest/java/com/mercari/puree/TagPatternTest.java
@@ -31,6 +31,8 @@ public class TagPatternTest {
         assertTrue(TagPattern.fromString("**").match(""));
         assertTrue(TagPattern.fromString("**").match("``!!``"));
         assertTrue(TagPattern.fromString("tag.**").match("tag"));
+        assertTrue(TagPattern.fromString("tag...").match("tag"));
+        assertTrue(TagPattern.fromString("tag...").match("tag.."));
     }
 
     @Test
@@ -46,6 +48,7 @@ public class TagPatternTest {
         assertFalse(TagPattern.fromString("a.*.*.c").match("a.b.c"));
         assertFalse(TagPattern.fromString("a").match(""));
         assertFalse(TagPattern.fromString("a").match("``!!"));
+        assertFalse(TagPattern.fromString("tag...").match("tag..a"));
     }
 
     @Test

--- a/puree/src/androidTest/java/com/mercari/puree/outputs/PureeBufferedOutputTest.java
+++ b/puree/src/androidTest/java/com/mercari/puree/outputs/PureeBufferedOutputTest.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
@@ -142,8 +143,7 @@ public class PureeBufferedOutputTest {
         @Nonnull
         @Override
         public TagPattern getTagPattern() {
-            TagPattern tag = TagPattern.fromString("tag.*");
-            return tag != null ? tag : TagPattern.getDefaultInstance();
+            return Objects.requireNonNull(TagPattern.fromString("tag.*"));
         }
     }
 

--- a/puree/src/main/java/com/mercari/puree/Puree.java
+++ b/puree/src/main/java/com/mercari/puree/Puree.java
@@ -40,6 +40,19 @@ public class Puree {
     }
 
     /**
+     * Try to send log with a tag
+     * <p>
+     * This log is sent immediately or put into a buffer depending on the output plugin.
+     *
+     * @param log {@link PureeLog}.
+     * @param tag Tag to match with TagPattern {@link TagPattern}.
+     */
+    public static void send(final PureeLog log, String tag) {
+        checkIfPureeHasInitialized();
+        logger.send(log);
+    }
+
+    /**
      * Tries to send a protobuf log entry.
      * <p>
      * This log is sent immediately or put into a buffer depending on the output plugin.
@@ -48,6 +61,18 @@ public class Puree {
     public static void send(MessageLite protoLog) {
         checkIfPureeHasInitialized();
         logger.send(protoLog);
+    }
+
+    /**
+     * Tries to send a protobuf log entry with a tag
+     * <p>
+     * This log is sent immediately or put into a buffer depending on the output plugin.
+     * @param protoLog the protobuf object representing the log entry.
+     * @param tag Tag to match with TagPattern {@link TagPattern}.
+     */
+    public static void send(MessageLite protoLog, String tag) {
+        checkIfPureeHasInitialized();
+        logger.send(protoLog, tag);
     }
 
     /**

--- a/puree/src/main/java/com/mercari/puree/PureeLogger.java
+++ b/puree/src/main/java/com/mercari/puree/PureeLogger.java
@@ -22,6 +22,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class PureeLogger {
 
+    private static final String EMPTY_TAG = "";
+
     final Gson gson;
 
     final Map<Class<? extends PureeLog>, List<PureeOutput>> sourceOutputMap = new HashMap<>();
@@ -68,18 +70,29 @@ public class PureeLogger {
     }
 
     public void send(PureeLog log) {
+        send(log, EMPTY_TAG);
+    }
+
+    public void send(PureeLog log, String tag) {
         List<PureeOutput> outputs = getRegisteredOutputPlugins(log);
         for (PureeOutput output : outputs) {
-            JsonObject jsonLog = serializeLog(log);
-            output.receive(jsonLog);
+            if (output.getTagPattern().match(tag)) {
+                JsonObject jsonLog = serializeLog(log);
+                output.receive(jsonLog);
+            }
         }
     }
 
     public void send(MessageLite protoLog) {
+        send(protoLog, EMPTY_TAG);
+    }
+
+    public void send(MessageLite protoLog, String tag) {
         List<PureeProtobufOutput> outputs = getRegisteredOutputPlugins(protoLog);
-        String protoStr = protoLog.toString();
         for (PureeProtobufOutput output : outputs) {
-            output.receive(protoLog);
+            if (output.getTagPattern().match(tag)) {
+                output.receive(protoLog);
+            }
         }
     }
 

--- a/puree/src/main/java/com/mercari/puree/TagPattern.java
+++ b/puree/src/main/java/com/mercari/puree/TagPattern.java
@@ -26,6 +26,9 @@ public final class TagPattern {
      * @return whether pattern is valid
      */
     private static boolean isValidPattern(String pattern) {
+        if (pattern == null) {
+            return false;
+        }
         String[] patternElements = pattern.split(SEPARATOR);
         if (patternElements.length == 0) {
             return false;

--- a/puree/src/main/java/com/mercari/puree/outputs/PureeOutput.java
+++ b/puree/src/main/java/com/mercari/puree/outputs/PureeOutput.java
@@ -4,6 +4,7 @@ import com.mercari.puree.PureeFilter;
 import com.google.gson.JsonObject;
 
 import com.mercari.puree.PureeLogger;
+import com.mercari.puree.TagPattern;
 import com.mercari.puree.storage.PureeStorage;
 
 import java.util.ArrayList;
@@ -53,6 +54,11 @@ public abstract class PureeOutput {
         }
 
         emit(filteredLog);
+    }
+
+    @Nonnull
+    public TagPattern getTagPattern() {
+        return TagPattern.getDefaultInstance();
     }
 
     @Nullable

--- a/puree/src/main/java/com/mercari/puree/outputs/PureeOutput.java
+++ b/puree/src/main/java/com/mercari/puree/outputs/PureeOutput.java
@@ -56,6 +56,11 @@ public abstract class PureeOutput {
         emit(filteredLog);
     }
 
+    /**
+     * Override this method in order to provide your own TagPattern.
+     * Please use {@link com.mercari.puree.TagPattern#fromString(String)} to generate
+     * a proper tag pattern.
+     */
     @Nonnull
     public TagPattern getTagPattern() {
         return TagPattern.getDefaultInstance();

--- a/puree/src/main/java/com/mercari/puree/outputs/PureeProtobufOutput.java
+++ b/puree/src/main/java/com/mercari/puree/outputs/PureeProtobufOutput.java
@@ -70,6 +70,11 @@ public abstract class PureeProtobufOutput {
         // do nothing because PureeOutput don't have any buffers.
     }
 
+    /**
+     * Override this method in order to provide your own TagPattern.
+     * Please use {@link com.mercari.puree.TagPattern#fromString(String)} to generate
+     * a proper tag pattern.
+     */
     @Nonnull
     public TagPattern getTagPattern() {
         return TagPattern.getDefaultInstance();

--- a/puree/src/main/java/com/mercari/puree/outputs/PureeProtobufOutput.java
+++ b/puree/src/main/java/com/mercari/puree/outputs/PureeProtobufOutput.java
@@ -2,6 +2,7 @@ package com.mercari.puree.outputs;
 
 import com.mercari.puree.PureeProtobufFilter;
 import com.mercari.puree.PureeLogger;
+import com.mercari.puree.TagPattern;
 import com.mercari.puree.storage.PureeStorage;
 import com.google.protobuf.MessageLite;
 
@@ -67,6 +68,11 @@ public abstract class PureeProtobufOutput {
 
     public void flush() {
         // do nothing because PureeOutput don't have any buffers.
+    }
+
+    @Nonnull
+    public TagPattern getTagPattern() {
+        return TagPattern.getDefaultInstance();
     }
 
     @Nonnull


### PR DESCRIPTION
**Summary**
In order to filter PureeOutputs that share the same logClass, we decided to add TagPattern logic similar to what [puree-swift](https://github.com/cookpad/Puree-Swift/blob/master/Sources/Puree/TagPattern.swift) has. This will be done in 3 steps:
- [Add TagPattern with tests](https://github.com/mercari/puree-android/pull/7)
- Apply TagPattern logic to puree with tests
- Update Demo app/Readme with tagpattern

[Design Doc](https://docs.google.com/document/d/19sl4ShBw9odeOQA5fpLOmGFvQeN0jzXqMFrosx7q3TM/edit#)